### PR TITLE
replace /usr/bin/python with /usr/bin/python3

### DIFF
--- a/reportip.py
+++ b/reportip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*-coding:utf8-*-
 
 import socket


### PR DESCRIPTION
replace /usr/bin/python with /usr/bin/python3 for porting python3

Signed-off-by: Junbo Zheng <3273070@qq.com>